### PR TITLE
Fixed package name for admin panel

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "elucidata-react-coffee",
+  "name": "react-coffee",
   "main": "dist/react-coffee.js",
   "version": "0.8.0",
   "homepage": "https://github.com/elucidata/react-coffee",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "elucidata-react-coffee",
+  "name": "react-coffee",
   "version": "0.8.0",
   "description": "Build React components using natural CoffeeScript syntax.",
   "author": "Matt McCray <matt@elucidata.net>",


### PR DESCRIPTION
Npm could not install this package as it was named `elucidata-react-coffee`. Fixed this.